### PR TITLE
🐛 Fixed unused loop variable.

### DIFF
--- a/Runtime/Systems/EffectTriggerSystems.cs
+++ b/Runtime/Systems/EffectTriggerSystems.cs
@@ -1,4 +1,4 @@
-﻿using Unity.Burst;
+using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
 
@@ -92,7 +92,7 @@ namespace WaynGroup.Mgm.Skill
                         if (!Skill.ShouldApplyEffects()) continue;
                         for (int e = 0; e < effectBufferArray.Length; e++)
                         {
-                            EFFECT_BUFFER EffectBuffer = effectBufferArray[skillIndex];
+                            EFFECT_BUFFER EffectBuffer = effectBufferArray[e];
                             if (EffectBuffer.SkillIndex != skillIndex) continue;
 
                             EffectContextWriter.WriteContextualizedEffect(entityIndex, ref ConsumerWriter, EffectBuffer.Effect, targets[entityIndex].Value);


### PR DESCRIPTION
Hey 👋 

I think you meant to use `e` in inside the for loop. I think it works currently given your test setup, but will probably crash with different skill/effect counts/ids.